### PR TITLE
Use rake compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmtags
 coverage
 rdoc
 pkg
+tmp
 
 ## RUBINIUS
 *.rbc


### PR DESCRIPTION
These modification reduce the build task code and provide a standardized structure which can be used later on to generate native gems and cross platform binaries (e.g. Ruby for Windows)

Please consider these modifications to be included.

Thank you.
