### PR TITLE
/etc/hosts not closed

### DIFF
--- a/lib/cool.io/dns_resolver.rb
+++ b/lib/cool.io/dns_resolver.rb
@@ -44,10 +44,12 @@ module Coolio
     # Query /etc/hosts (or the specified hostfile) for the given host
     def self.hosts(host, hostfile = HOSTS)
       hosts = {}
-      File.open(hostfile).each_line do |host_entry|
-        entries = host_entry.gsub(/#.*$/, '').gsub(/\s+/, ' ').split(' ')
-        addr = entries.shift
-        entries.each { |e| hosts[e] ||= addr }
+      File.open(hostfile) do |f|
+        f.each_line do |host_entry|
+          entries = host_entry.gsub(/#.*$/, '').gsub(/\s+/, ' ').split(' ')
+          addr = entries.shift
+          entries.each { |e| hosts[e] ||= addr }
+        end
       end
 
       hosts[host]


### PR DESCRIPTION
Hello,

Current implementation doesn't close /etc/hosts file after reading it, resulting in a _Too many open files_ error if you resolve many hostnames is a short period of time. There's a simple patch in my repository.

Regards,
Kővágó, Zoltán
