### PR TITLE
fixed build error with Ruby 2.2.0

### DIFF
--- a/ext/cool.io/loop.c
+++ b/ext/cool.io/loop.c
@@ -205,7 +205,7 @@ static VALUE Coolio_Loop_run_once(VALUE self)
   return nevents;
 }
 
-#ifdef HAVE_RB_THREAD_BLOCKING_REGION
+#if defined(HAVE_RB_THREAD_BLOCKING_REGION) || defined(HAVE_RB_THREAD_CALL_WITHOUT_GVL)
 #define HAVE_EV_LOOP_ONESHOT
 
 static void Coolio_Loop_ev_loop_oneshot(struct Coolio_Loop *loop_data)


### PR DESCRIPTION
I fixed build error with Ruby 2.2.0, this fixes is similar solution of https://github.com/tarcieri/cool.io/commit/a908df724d0090be7cfb784ea3c49046b44e93d5
