### PR TITLE
Stop to use instance eval for callback

### DIFF
--- a/examples/callbacked_echo_server.rb
+++ b/examples/callbacked_echo_server.rb
@@ -11,11 +11,11 @@ server = Cool.io::TCPServer.new(ADDR, PORT) do |connection|
   puts "#{connection.remote_addr}:#{connection.remote_port} connected"
 
   connection.on_close do
-    puts "#{remote_addr}:#{remote_port} disconnected"
+    puts "#{connection.remote_addr}:#{connection.remote_port} disconnected"
   end
 
   connection.on_read do |data|
-    write data
+    connection.write data
   end
 end
 server.attach(event_loop)

--- a/examples/callbacked_echo_server.rb
+++ b/examples/callbacked_echo_server.rb
@@ -1,0 +1,24 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
+require 'rubygems'
+require 'cool.io'
+
+ADDR = '127.0.0.1'
+PORT = 4321
+
+event_loop = Cool.io::Loop.default
+server = Cool.io::TCPServer.new(ADDR, PORT) do |connection|
+  puts "#{connection.remote_addr}:#{connection.remote_port} connected"
+
+  connection.on_close do
+    puts "#{remote_addr}:#{remote_port} disconnected"
+  end
+
+  connection.on_read do |data|
+    write data
+  end
+end
+server.attach(event_loop)
+
+puts "Echo server listening on #{ADDR}:#{PORT}"
+event_loop.run

--- a/lib/cool.io/meta.rb
+++ b/lib/cool.io/meta.rb
@@ -39,7 +39,7 @@ module Coolio
             end
 
             if defined? @#{method}_callback and @#{method}_callback
-              instance_exec(*args, &@#{method}_callback)
+              @#{method}_callback.call(*args)
             end
           end
         EOD


### PR DESCRIPTION
CAUTION: THIS IS BACKWARD INCOMPATIBLE CHANGE!

Normally, block is evaluated without changing `self` in Ruby. For
example:

    elements = [1]
    elements.each do |element|
      p [self, elements] # => [main, [1]]
    end

But callback block in Cool.io is evaluated with changing `self` to
object that has the event. For example:

    require "cool.io"

    event_loop = Cool.io::Loop.default
    server = Cool.io::TCPServer.new("127.0.0.1", 2929) do |connection|
      connection.on_close do
        p(self == connection) # => true
      end
    end
    server.attach(event_loop)
    event_loop.run

We need to create a wrapper Proc to evaluate callback block in original
scope such as:

    require "cool.io"

    event_loop = Cool.io::Loop.default
    server = Cool.io::TCPServer.new("127.0.0.1", 2929) do |connection|
      self_in_tcp_server_new_block = self
      on_close = lambda do
        p(self == connection) # => false
        p(self == self_in_tcp_server_new_block) # => true
      end
      connection.on_close do
        on_close.call
      end
    end
    server.attach(event_loop)
    event_loop.run

The current API is inconsistent with built-in Ruby methods. API with
this change is consistent with built-in Ruby methods.

See also https://github.com/kou/cool.io/commit/c1c9a7ddfc50a6f1fedfad8f600bad79a2ff71c1#diff-0 for confirming how API change.