### PR TITLE
Sleep in timeout instead of select on Windows

### DIFF
--- a/ext/libev/ev_select.c
+++ b/ext/libev/ev_select.c
@@ -207,7 +207,10 @@ select_poll (EV_P_ ev_tstamp timeout)
    * (Visual C++ 12), it cause WaitForMultipleObjects stuck.
    */
   if (EV_WIN_FD_COUNT(vec_ri) == 0 && EV_WIN_FD_COUNT(vec_wi) == 0)
-    return;
+    {
+      ev_sleep (timeout);
+      return;
+    }
 #endif
 
   EV_RELEASE_CB;


### PR DESCRIPTION
When no fds are specified, libev uses select as simple sleep.
But previous fix for Windows (b8ab9288f1b8c0fae8fdef1e84deb5a3df6fba1b)
returned immediately. fix fluent/fluentd#276