### PR TITLE
Use rake-compiler-dock for cross compiling fat gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,8 @@ Rake::ExtensionTask.new('cool.io_ext', spec) do |ext|
   configure_cross_compilation(ext)
 end
 
+# Note that this rake-compiler-dock rake task dose not support bundle install(1) --path option.
+# Please use bundle install instead when you execute this rake task.
 namespace :build do
   desc 'Build gems for Windows per rake-compiler-dock'
   task :windows do

--- a/Rakefile
+++ b/Rakefile
@@ -41,6 +41,17 @@ Rake::ExtensionTask.new('cool.io_ext', spec) do |ext|
   configure_cross_compilation(ext)
 end
 
+namespace :build do
+  desc 'Build gems for Windows per rake-compiler-dock'
+  task :windows do
+    require 'rake_compiler_dock'
+    RakeCompilerDock.sh <<-CROSS
+      bundle
+      rake cross native gem RUBY_CC_VERSION='2.0.0:2.1.6:2.2.2'
+    CROSS
+  end
+end
+
 # adapted from http://flavoriffic.blogspot.com/2009/06/easily-valgrind-gdb-your-ruby-c.html
 def specs_command
   require "find"

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ spec = eval(File.read("cool.io.gemspec"))
 def configure_cross_compilation(ext)
   unless RUBY_PLATFORM =~ /mswin|mingw/
     ext.cross_compile = true
-    ext.cross_platform = 'i386-mingw32'#['i386-mswin32-60', 'i386-mingw32']
+    ext.cross_platform = ['x86-mingw32', 'x64-mingw32']
   end
 end
 

--- a/cool.io.gemspec
+++ b/cool.io.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_development_dependency "rake-compiler", "~> 0.8.3"
+  s.add_development_dependency "rake-compiler", "~> 0.9.5"
   s.add_development_dependency "rake-compiler-dock", "~> 0.4.3"
   s.add_development_dependency "rspec", ">= 2.13.0"
   s.add_development_dependency "rdoc", ">= 3.6.0"

--- a/cool.io.gemspec
+++ b/cool.io.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   
   s.add_development_dependency "rake-compiler", "~> 0.8.3"
+  s.add_development_dependency "rake-compiler-dock", "~> 0.4.3"
   s.add_development_dependency "rspec", ">= 2.13.0"
   s.add_development_dependency "rdoc", ">= 3.6.0"
 end


### PR DESCRIPTION
This PR also fixes `cross_platform`.

Note that this `rake-compiler-dock` rake task dose not support bundle install(1) --path option. Please use `bundle install` instead when you execute this rake task.