### PR TITLE
Use SleepEx instead of Sleep

### DIFF
--- a/ext/libev/ev_select.c
+++ b/ext/libev/ev_select.c
@@ -184,34 +184,12 @@ select_modify (EV_P_ int fd, int oev, int nev)
   }
 }
 
-#undef socket
-
 static void
 select_poll (EV_P_ ev_tstamp timeout)
 {
   struct timeval tv;
   int res;
   int fd_setsize;
-
-#ifdef _WIN32
-  /* POSIX defines the case when the readfds, writefds, and errorfds arguments
-   * are all null pointers.
-   * http://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html
-   *
-   * But Windows doesn't define such case; simply say don't so that
-   * https://msdn.microsoft.com/en-us/library/windows/desktop/ms740141(v=vs.85).aspx
-   * "Any two of the parameters, readfds, writefds, or exceptfds, can be given
-   * as null. At least one must be non-null, and any non-null descriptor set
-   * must contain at least one handle to a socket."
-   * At least on Windows Server 2012 R2 Datacenter with Visual Studio 2013
-   * (Visual C++ 12), it cause WaitForMultipleObjects stuck.
-   */
-  if (EV_WIN_FD_COUNT(vec_ri) == 0 && EV_WIN_FD_COUNT(vec_wi) == 0)
-    {
-      ev_sleep (timeout);
-      return;
-    }
-#endif
 
   EV_RELEASE_CB;
   EV_TV_SET (tv, timeout);
@@ -268,7 +246,7 @@ select_poll (EV_P_ ev_tstamp timeout)
           if (timeout)
             {
               unsigned long ms = (unsigned long)(timeout * 1e3);
-              Sleep (ms ? ms : 1);
+              SleepEx (ms ? ms : 1, TRUE);
             }
 
           return;


### PR DESCRIPTION
Sleep is replaced with rb_w32_Sleep by Ruby,
which tries to release GVL, though select_poll
doesn't have GVL.