### PR TITLE
Add object info to error message

### DIFF
--- a/ext/cool.io/stat_watcher.c
+++ b/ext/cool.io/stat_watcher.c
@@ -116,8 +116,8 @@ static VALUE Coolio_StatWatcher_attach(VALUE self, VALUE loop)
   struct Coolio_Loop *loop_data;
   struct Coolio_Watcher *watcher_data;
 
-	if(!rb_obj_is_kind_of(loop, cCoolio_Loop))
-		rb_raise(rb_eArgError, "expected loop to be an instance of Coolio::Loop");
+  if(!rb_obj_is_kind_of(loop, cCoolio_Loop))
+    rb_raise(rb_eArgError, "expected loop to be an instance of Coolio::Loop, not %s", RSTRING_PTR(rb_inspect(loop)));
 
   Data_Get_Struct(loop, struct Coolio_Loop, loop_data);
   Data_Get_Struct(self, struct Coolio_Watcher, watcher_data);

--- a/ext/cool.io/timer_watcher.c
+++ b/ext/cool.io/timer_watcher.c
@@ -95,8 +95,8 @@ static VALUE Coolio_TimerWatcher_attach(VALUE self, VALUE loop)
   struct Coolio_Loop *loop_data;
   struct Coolio_Watcher *watcher_data;
     
-	if(!rb_obj_is_kind_of(loop, cCoolio_Loop))
-		rb_raise(rb_eArgError, "expected loop to be an instance of Coolio::Loop");
+  if(!rb_obj_is_kind_of(loop, cCoolio_Loop))
+    rb_raise(rb_eArgError, "expected loop to be an instance of Coolio::Loop, not %s", RSTRING_PTR(rb_inspect(loop)));
 
   Data_Get_Struct(loop, struct Coolio_Loop, loop_data);
   Data_Get_Struct(self, struct Coolio_Watcher, watcher_data);

--- a/ext/cool.io/watcher.h
+++ b/ext/cool.io/watcher.h
@@ -12,7 +12,7 @@
   struct Coolio_Loop *loop_data; \
   \
   if(!rb_obj_is_kind_of(loop, cCoolio_Loop)) \
-    rb_raise(rb_eArgError, "expected loop to be an instance of Coolio::Loop"); \
+    rb_raise(rb_eArgError, "expected loop to be an instance of Coolio::Loop, not %s", RSTRING_PTR(rb_inspect(loop))); \
   \
   Data_Get_Struct(watcher, struct Coolio_Watcher, watcher_data); \
   Data_Get_Struct(loop, struct Coolio_Loop, loop_data); \


### PR DESCRIPTION
Debugging for below case:
https://gist.github.com/shoichikaji/924aa9738c5eda79bfaa

New message example:
```
expected loop to be an instance of Coolio::Loop, not nil (ArgumentError)
```