### PR TITLE
Separate socket listen approach in TCPServer for Windows

### DIFF
--- a/lib/cool.io/listener.rb
+++ b/lib/cool.io/listener.rb
@@ -59,6 +59,9 @@ module Coolio
     else
       def on_readable
         begin
+          # In Windows, accept_nonblock() with multiple processes
+          # causes thundering herd problem.
+          # To avoid this, we need to use accept().
           on_connection @listen_socket.accept
         rescue Errno::EAGAIN, Errno::ECONNABORTED
         end

--- a/lib/cool.io/listener.rb
+++ b/lib/cool.io/listener.rb
@@ -40,19 +40,28 @@ module Coolio
     #########
 
     # Coolio callback for handling new connections
-    def on_readable
-      begin
-        on_connection @listen_socket.accept_nonblock
-      rescue Errno::EAGAIN, Errno::ECONNABORTED
-        # EAGAIN can be triggered here if the socket is shared between
-        # multiple processes and a thundering herd is woken up to accept
-        # one connection, only one process will get the connection and
-        # the others will be awoken.
-        # ECONNABORTED is documented in accept() manpages but modern TCP
-        # stacks with syncookies and/or accept()-filtering for DoS
-        # protection do not see it.  In any case this error is harmless
-        # and we should instead spend our time with clients that follow
-        # through on connection attempts.
+    unless RUBY_PLATFORM =~ /mingw|mswin/
+      def on_readable
+        begin
+          on_connection @listen_socket.accept_nonblock
+        rescue Errno::EAGAIN, Errno::ECONNABORTED
+          # EAGAIN can be triggered here if the socket is shared between
+          # multiple processes and a thundering herd is woken up to accept
+          # one connection, only one process will get the connection and
+          # the others will be awoken.
+          # ECONNABORTED is documented in accept() manpages but modern TCP
+          # stacks with syncookies and/or accept()-filtering for DoS
+          # protection do not see it.  In any case this error is harmless
+          # and we should instead spend our time with clients that follow
+          # through on connection attempts.
+        end
+      end
+    else
+      def on_readable
+        begin
+          on_connection @listen_socket.accept
+        rescue Errno::EAGAIN, Errno::ECONNABORTED
+        end
       end
     end
   end


### PR DESCRIPTION
By adding this class, it can solve 2 problems.
1. We have to listen socket again if we use Coolio::TCPServer class for already listened and binded socket.
2. in windows, accept_nonblock with multiple processes causes thundering herd problem. Then we need to use accept function.

Problem1 can be solved also by using Server class directly.
Problem2 can be solved also by branching if it's windows or not when accepting in Listener class. But I think it's a waste of time to branch every accepting.

By this commit, it can solve both of the problems, but if you think it's needless, please ignore this commit.