### PR TITLE
Update rake-compiler-dock to 0.5.x

### DIFF
--- a/cool.io.gemspec
+++ b/cool.io.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   
   s.add_development_dependency "rake-compiler", "~> 0.9.5"
-  s.add_development_dependency "rake-compiler-dock", "~> 0.4.3"
+  s.add_development_dependency "rake-compiler-dock", "~> 0.5.0"
   s.add_development_dependency "rspec", ">= 2.13.0"
   s.add_development_dependency "rdoc", ">= 3.6.0"
 end


### PR DESCRIPTION
rake-cpmpiler-dock supports Ruby 2.3.0.
Let's update this gem!