### PR TITLE
Fix compile error on Solaris and Ruby 2.3.0

### DIFF
--- a/ext/cool.io/extconf.rb
+++ b/ext/cool.io/extconf.rb
@@ -42,6 +42,11 @@ else
   end
 end
 
+if RUBY_PLATFORM =~ /solaris/
+  # libev/ev.c requires NSIG which is undefined if _XOPEN_SOURCE is defined
+  $defs << '-D__EXTENSIONS__'
+end
+
 $LIBS << ' ' << libs.join(' ')
 
 dir_config('cool.io_ext')


### PR DESCRIPTION
cool.io's extension doesn't compile on Solaris and Ruby 2.3.0.

With Ruby 2.3.0 (>= r52703), extensions may be compiled with _XOPEN_SOURCE on Solaris.
_XOPEN_SOURCE disables NSIG (in signal.h) which ext/libev/ev.c requires.