### PR TITLE
Update cross build for ruby-2.3 and disable bundler usage for extconf.rb

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -49,7 +49,7 @@ namespace :build do
     require 'rake_compiler_dock'
     RakeCompilerDock.sh <<-CROSS
       bundle
-      rake cross native gem RUBY_CC_VERSION='2.0.0:2.1.6:2.2.2'
+      rake cross native gem RUBY_CC_VERSION='2.0.0:2.1.6:2.2.2:2.3.0'
     CROSS
   end
 end

--- a/cool.io.gemspec
+++ b/cool.io.gemspec
@@ -21,9 +21,9 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  
+
   s.add_development_dependency "rake-compiler", "~> 0.9.5"
-  s.add_development_dependency "rake-compiler-dock", "~> 0.5.0"
+  s.add_development_dependency "rake-compiler-dock", "~> 0.5.1"
   s.add_development_dependency "rspec", ">= 2.13.0"
   s.add_development_dependency "rdoc", ">= 3.6.0"
 end


### PR DESCRIPTION
The faked ruby environment for cross build doesn't work with bundler and
failed with the following error:

  /usr/local/rvm/rubies/ruby-2.3.0/bin/ruby -I. ../../../../ext/iobuffer/extconf.rb
  Could not find json-1.8.3 in any of the sources
  Run `bundle install` to install missing gems.
  rake aborted!