### PR TITLE
timer_watcher: Fix invalid rb_funcall to avoid broken call

### DIFF
--- a/ext/cool.io/timer_watcher.c
+++ b/ext/cool.io/timer_watcher.c
@@ -213,7 +213,7 @@ static void Coolio_TimerWatcher_libev_callback(struct ev_loop *ev_loop, struct e
 static void Coolio_TimerWatcher_dispatch_callback(VALUE self, int revents)
 { 
   if(revents & EV_TIMEOUT)
-    rb_funcall(self, rb_intern("on_timer"), 0, 0);
+    rb_funcall(self, rb_intern("on_timer"), 0);
   else
     rb_raise(rb_eRuntimeError, "unknown revents value for ev_timer: %d", revents);
 }


### PR DESCRIPTION
This causes the error with ruby 2.5 on Mac:

```
Traceback (most recent call last):
        3: from t_test.rb:16:in `<main>'
        2: from /Users/repeatedly/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/cool.io-1.5.1/lib/cool.io/loop.rb:88:in `run'
        1: from /Users/repeatedly/.rbenv/versions/2.5.0-dev/lib/ruby/gems/2.5.0/gems/cool.io-1.5.1/lib/cool.io/loop.rb:88:in `run_once'
t_test.rb:8:in `on_timer': wrong number of arguments (given 8, expected 0) (ArgumentError)
```

Patch by nurse.