### PR TITLE
Add recommended gemspec attributes - licenses

### DIFF
--- a/cool.io.gemspec
+++ b/cool.io.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.summary     = "A cool framework for doing high performance I/O in Ruby"
   s.description = "Cool.io provides a high performance event framework for Ruby which uses the libev C library"
   s.extensions = ["ext/cool.io/extconf.rb", "ext/iobuffer/extconf.rb"]
+  s.licenses   = ["MIT"]
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")


### PR DESCRIPTION
It is better to add licenses explicitly in gemspec.

  % gem specification cool.io | \grep licenses
  licenses: []

ref. https://guides.rubygems.org/specification-reference/