### PR TITLE
Suppress implicit declaration errors

### DIFF
--- a/ext/cool.io/cool.io.h
+++ b/ext/cool.io/cool.io.h
@@ -56,4 +56,11 @@ struct Coolio_Watcher
 
 void Coolio_Loop_process_event(VALUE watcher, int revents);
 
+void Init_coolio_loop();
+void Init_coolio_watcher();
+void Init_coolio_iowatcher();
+void Init_coolio_timer_watcher();
+void Init_coolio_stat_watcher();
+void Init_coolio_utils();
+
 #endif

--- a/ext/cool.io/cool.io.h
+++ b/ext/cool.io/cool.io.h
@@ -8,7 +8,11 @@
 #define COOLIO_H
 
 #include "ruby.h"
+#if defined(HAVE_RUBY_IO_H)
+#include "ruby/io.h"
+#else
 #include "rubyio.h"
+#endif
 
 #ifdef GetReadFile
 #define FPTR_TO_FD(fptr) (fileno(GetReadFile(fptr)))

--- a/ext/cool.io/extconf.rb
+++ b/ext/cool.io/extconf.rb
@@ -10,6 +10,10 @@ have_func('rb_thread_alone')
 have_func('rb_str_set_len')
 have_library('rt', 'clock_gettime')
 
+if have_header('ruby/io.h')
+  $defs << '-DHAVE_RUBY_IO_H'
+end
+
 if have_header('sys/select.h')
   $defs << '-DEV_USE_SELECT'
 end

--- a/ext/cool.io/extconf.rb
+++ b/ext/cool.io/extconf.rb
@@ -14,6 +14,10 @@ if have_header('ruby/io.h')
   $defs << '-DHAVE_RUBY_IO_H'
 end
 
+if have_header('ruby/thread.h')
+  $defs << '-DHAVE_RUBY_THREAD_H'
+end
+
 if have_header('sys/select.h')
   $defs << '-DEV_USE_SELECT'
 end

--- a/ext/cool.io/iowatcher.c
+++ b/ext/cool.io/iowatcher.c
@@ -5,7 +5,11 @@
  */
 
 #include "ruby.h"
+#if defined(HAVE_RUBY_IO_H)
+#include "ruby/io.h"
+#else
 #include "rubyio.h"
+#endif
 
 #include "ev_wrap.h"
 

--- a/ext/cool.io/utils.c
+++ b/ext/cool.io/utils.c
@@ -15,6 +15,11 @@
 #include <sys/sysctl.h>
 #endif
 
+#ifdef HAVE_SYSCTLBYNAME
+#include <sys/sysctl.h>
+#include <sys/types.h>
+#endif
+
 static VALUE mCoolio = Qnil;
 static VALUE cCoolio_Utils = Qnil;
 

--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -39,6 +39,7 @@
 
 /* ########## COOLIO PATCHERY HO! ########## */
 #include "ruby.h"
+#include "ruby/thread.h"
 /* ######################################## */
 
 /* this big block deduces configuration from config.h */

--- a/ext/libev/ev.c
+++ b/ext/libev/ev.c
@@ -39,7 +39,9 @@
 
 /* ########## COOLIO PATCHERY HO! ########## */
 #include "ruby.h"
+#if defined(HAVE_RUBY_THREAD_H)
 #include "ruby/thread.h"
+#endif
 /* ######################################## */
 
 /* this big block deduces configuration from config.h */


### PR DESCRIPTION
macOS's latest compiler complains implicit functions are invalid in C99.
And use `ruby/io.h` instead of `rubyio.h` if available.

Otherwise, the following errors occurred:

```
../../../../ext/cool.io/cool.io_ext.c:19:3: error: implicit declaration of function 'Init_coolio_loop' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  Init_coolio_loop();
  ^
../../../../ext/cool.io/cool.io_ext.c:20:3: error: implicit declaration of function 'Init_coolio_watcher' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  Init_coolio_watcher();
  ^
../../../../ext/cool.io/cool.io_ext.c:21:3: error: implicit declaration of function 'Init_coolio_iowatcher' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  Init_coolio_iowatcher();
  ^
../../../../ext/cool.io/cool.io_ext.c:21:3: note: did you mean 'Init_coolio_watcher'?
../../../../ext/cool.io/cool.io_ext.c:20:3: note: 'Init_coolio_watcher' declared here
  Init_coolio_watcher();
  ^
../../../../ext/cool.io/cool.io_ext.c:22:3: error: implicit declaration of function 'Init_coolio_timer_watcher' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  Init_coolio_timer_watcher();
  ^
../../../../ext/cool.io/cool.io_ext.c:22:3: note: did you mean 'Init_coolio_iowatcher'?
../../../../ext/cool.io/cool.io_ext.c:21:3: note: 'Init_coolio_iowatcher' declared here
  Init_coolio_iowatcher();
  ^
../../../../ext/cool.io/cool.io_ext.c:23:3: error: implicit declaration of function 'Init_coolio_stat_watcher' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  Init_coolio_stat_watcher();
  ^
../../../../ext/cool.io/cool.io_ext.c:24:3: error: implicit declaration of function 'Init_coolio_utils' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  Init_coolio_utils();
  ^
../../../../ext/cool.io/cool.io_ext.c:24:3: note: did you mean 'Init_coolio_loop'?
../../../../ext/cool.io/cool.io_ext.c:19:3: note: 'Init_coolio_loop' declared here
  Init_coolio_loop();
  ^
1 warning and 6 errors generated.
make: *** [cool.io_ext.o] Error 1
rake aborted!
```

```
In file included from ../../../../ext/cool.io/libev.c:8:
../../../../ext/cool.io/../libev/ev.c:3768:9: error: implicit declaration of function 'rb_thread_call_without_gvl' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        rb_thread_call_without_gvl(ev_backend_poll, (void *)&poll_args, RUBY_UBF_IO, 0);
        ^
```

```
compiling ../../../../ext/cool.io/utils.c
../../../../ext/cool.io/utils.c:66:6: error: implicit declaration of function 'sysctlbyname' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
  if(sysctlbyname("hw.ncpu", &ncpus, &size, NULL, 0)) 
     ^
```