### PR TITLE
Set fallback local loopback address by default

### DIFF
--- a/lib/cool.io/dns_resolver.rb
+++ b/lib/cool.io/dns_resolver.rb
@@ -49,6 +49,15 @@ module Coolio
           entries.each { |e| hosts[e] ||= addr }
         end
       end
+      if hosts.empty?
+        # On Windows, there is a case that hosts file doesn't have entry by default
+        # and preferred IPv4/IPv6 behavior may be changed by registry key [1], so
+        # "localhost" should be resolved by getaddrinfo.
+        # (first[3] means preferred resolved IP address ::1 or 127.0.0.1)
+        # [1] https://docs.microsoft.com/en-us/troubleshoot/windows-server/networking/configure-ipv6-in-windows
+        require "socket"
+        hosts["localhost"] = ::Socket.getaddrinfo("localhost", nil).first[3]
+      end
 
       hosts[host]
     end

--- a/spec/dns_spec.rb
+++ b/spec/dns_spec.rb
@@ -19,6 +19,7 @@ end
 describe "DNS" do
   before :each do
     @loop = Cool.io::Loop.new
+    @preferred_localhost_address = ::Socket.getaddrinfo("localhost", nil).first[3]
   end
   
   it "connects to valid domains" do
@@ -39,5 +40,11 @@ describe "DNS" do
     expect do
       @loop.run
     end.to raise_error(WontResolve)
+  end
+
+  it "resolve localhost even though hosts is empty" do
+    Tempfile.open("empty") do |file|
+      expect( Coolio::DNSResolver.hosts("localhost", file.path)).to eq @preferred_localhost_address
+    end
   end
 end


### PR DESCRIPTION
There is a case that localhost is not defined in
Resolv::Hosts::DefaultFileName on Windows.
(C:\Windows\system32\drivers\etc\hosts)

In such a case, when a program assumes that
localhost is resolved to local loopback address, it
does not work as expected.