### PR TITLE
Detect fallback local loopback address correctly

### DIFF
--- a/lib/cool.io/dns_resolver.rb
+++ b/lib/cool.io/dns_resolver.rb
@@ -49,7 +49,7 @@ module Coolio
           entries.each { |e| hosts[e] ||= addr }
         end
       end
-      if hosts.empty?
+      unless hosts.key?("localhost")
         # On Windows, there is a case that hosts file doesn't have entry by default
         # and preferred IPv4/IPv6 behavior may be changed by registry key [1], so
         # "localhost" should be resolved by getaddrinfo.

--- a/spec/dns_spec.rb
+++ b/spec/dns_spec.rb
@@ -47,4 +47,12 @@ describe "DNS" do
       expect( Coolio::DNSResolver.hosts("localhost", file.path)).to eq @preferred_localhost_address
     end
   end
+
+  it "resolve missing localhost even though hosts entries exist" do
+    Tempfile.open("empty") do |file|
+      file.puts("127.0.0.1 example.internal")
+      file.flush
+      expect( Coolio::DNSResolver.hosts("localhost", file.path)).to eq @preferred_localhost_address
+    end
+  end
 end


### PR DESCRIPTION
In the previous PR, #71, local loopback address is
detected even though hosts file is empty, but
there is a case that hosts file is NOT empty
and localhost entry is missing. In such a case,
Coolio::DNSResolver.hosts("localhost") does not work
as expected. This PR should fix such case.