### PR TITLE
Use xfree() for heap area allocated by xmalloc

### DIFF
--- a/ext/cool.io/buffer.c
+++ b/ext/cool.io/buffer.c
@@ -479,7 +479,7 @@ buffer_free(struct buffer * buf)
     buffer_clear(buf);
     buffer_free_pool(buf);
 
-    free(buf);
+    xfree(buf);
 }
 
 /* Free the memory pool */
@@ -491,7 +491,7 @@ buffer_free_pool(struct buffer * buf)
     while (buf->pool_head) {
         tmp = buf->pool_head;
         buf->pool_head = tmp->next;
-        free(tmp);
+        xfree(tmp);
     }
 
     buf->pool_tail = 0;


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

In `buffer.c`, it uses `xmalloc` Ruby API to allocate heap area.

* https://github.com/socketry/cool.io/blob/6f85a2a104488e5c7cb128b9a83058d28ba16d37/ext/cool.io/buffer.c#L445
* https://github.com/socketry/cool.io/blob/6f85a2a104488e5c7cb128b9a83058d28ba16d37/ext/cool.io/buffer.c#L509

To release the areas, it should use `xfree` instead of `free`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
