### PR TITLE
Ignore IPv6 nameservers to prevent Socket::ResolutionError

### DIFF
--- a/lib/cool.io/dns_resolver.rb
+++ b/lib/cool.io/dns_resolver.rb
@@ -67,8 +67,9 @@ module Coolio
     # list of nameservers to query.  By default the resolver will
     # use nameservers listed in /etc/resolv.conf
     def initialize(hostname, *nameservers)
+      nameservers = reject_ipv6_nameservers(nameservers)
       if nameservers.empty?
-        nameservers = Resolv::DNS::Config.default_config_hash[:nameserver]
+        nameservers = reject_ipv6_nameservers(Resolv::DNS::Config.default_config_hash[:nameserver])
         raise RuntimeError, "no nameservers found" if nameservers.empty? # TODO just call resolve_failed, not raise [also handle Errno::ENOENT)]
       end
 
@@ -201,6 +202,12 @@ module Coolio
       end
 
       nil
+    end
+
+    private
+
+    def reject_ipv6_nameservers(nameservers)
+      nameservers.reject { |ns| ns.include?(':') }
     end
 
     class Timeout < TimerWatcher

--- a/spec/dns_spec.rb
+++ b/spec/dns_spec.rb
@@ -56,4 +56,24 @@ describe "DNS" do
       expect( Coolio::DNSResolver.hosts("localhost", file.path)).to eq @preferred_localhost_address
     end
   end
+
+  describe "IPv6 nameserver filtering" do
+    it "ignores IPv6 nameservers provided in arguments" do
+      resolver = Coolio::DNSResolver.new("example.com", "8.8.8.8", "2001:4860:4860::8888", "1.1.1.1")
+
+      nameservers = resolver.instance_variable_get(:@nameservers)
+      expect(nameservers).to eq(["8.8.8.8", "1.1.1.1"])
+    end
+
+    it "falls back to default IPv4 config if only IPv6 addresses are provided" do
+      allow(Resolv::DNS::Config).to receive(:default_config_hash).and_return({
+        nameserver: ["8.8.4.4", "2001:4860:4860::8844"]
+      })
+
+      resolver = Coolio::DNSResolver.new("example.com", "2001:4860:4860::8888")
+
+      nameservers = resolver.instance_variable_get(:@nameservers)
+      expect(nameservers).to eq(["8.8.4.4"])
+    end
+  end
 end


### PR DESCRIPTION
The DNSResolver currently does not support IPv6 and initializes an IPv4 (AF_INET) UDP socket. 
https://github.com/socketry/cool.io/blob/28366d0d0306ac79374f9bc1471074c04cbfd33f/lib/cool.io/dns_resolver.rb#L8-L10

However, modern OS environments often include IPv6 addresses in `/etc/resolv.conf` by default.

When the resolver attempts to send a query to an IPv6 nameserver using the IPv4 socket, it crashes with: `Socket::ResolutionError: getaddrinfo: Address family for hostname not supported`

This will fix following error:
```
$ rspec spec/dns_spec.rb

DNS
  connects to valid domains (FAILED - 1)
  fires on_resolve_failed for invalid domains (FAILED - 2)
  resolve localhost even though hosts is empty
  resolve missing localhost even though hosts entries exist

Failures:

  1) DNS connects to valid domains
     Failure/Error: @socket.send request_message, 0, @nameservers.first, DNS_PORT

     Socket::ResolutionError:
       getaddrinfo: Address family for hostname not supported
     # ./lib/cool.io/dns_resolver.rb:118:in 'UDPSocket#send'
     # ./lib/cool.io/dns_resolver.rb:118:in 'Coolio::DNSResolver#send_request'
     # ./lib/cool.io/dns_resolver.rb:86:in 'Coolio::DNSResolver#attach'
     # (eval at ./lib/cool.io/meta.rb:15):3:in 'Coolio::TCPSocket#attach'
     # ./spec/dns_spec.rb:28:in 'block (2 levels) in <top (required)>'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:263:in 'BasicObject#instance_exec'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:263:in 'block in RSpec::Core::Example#run'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:511:in 'block in RSpec::Core::Example#with_around_and_singleton_context_hooks'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/example.rb:468:in 'block in RSpec::Core::Example#with_around_example_hooks'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in 'block in RSpec::Core::Hooks::HookCollections#run'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:624:in 'RSpec::Core::Hooks::HookCollections#run_around_example_hooks_for'
     # /home/watson/.rbenv/versions/4.0.1/lib/ruby/gems/4.0.0/gems/rspec-core-3.13.6/lib/rspec/core/hooks.rb:486:in 'RSpec::Core::Hooks::Hoo
...
```

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
