### PR TITLE
Fix flaky async_watcher_spec on macOS Ruby 3.2+

### DIFF
--- a/spec/async_watcher_spec.rb
+++ b/spec/async_watcher_spec.rb
@@ -30,7 +30,9 @@ describe Cool.io::AsyncWatcher, :env => :exclude_win do
     end
 
     # ensure children are ready
-    nr_fork.times { expect(rd.sysread(1)).to eq('.') }
+    # rd may be O_NONBLOCK on macOS Ruby 3.2+ (IO.pipe sets O_NONBLOCK); use read
+    # instead of sysread so EAGAIN on an empty pipe is retried transparently.
+    nr_fork.times { expect(rd.read(1)).to eq('.') }
 
     # send our signals
     nr_signal.times { aw.signal }


### PR DESCRIPTION
## Problem

`spec/async_watcher_spec.rb` fails intermittently on macOS with Ruby 3.2+.
The handshake on line 33 uses `rd.sysread(1)` to wait for each child to become ready:

```ruby
nr_fork.times { expect(rd.sysread(1)).to eq('.') }
```

## Root cause (macOS Ruby 3.2+, platform-conditional)

On macOS Ruby 3.2+, `IO.pipe` returns pipes with `O_NONBLOCK` already set on both ends:

```
rd F_GETFL = 0x4  (= O_NONBLOCK on macOS)
wr F_GETFL = 0x5  (= O_WRONLY | O_NONBLOCK)
```

This is unrelated to cool.io or libev — a bare `IO.pipe` call with no other code loaded reproduces it. `sysread` calls `read()` directly without any EAGAIN retry, so if the child has not yet written `'.'` when the parent reads, `Errno::EAGAIN` is raised.

Reproduced without cool.io using a minimal script (100 iterations × 2 reads):

```
Out of 200 sysread calls: 50 EAGAIN  (platform: arm64-darwin24, ruby: 3.2.6)
```

Linux is unaffected because `IO.pipe` there does not set `O_NONBLOCK`.

## Fix

Replace `sysread` with `read`, which handles `EAGAIN` internally and waits transparently for data regardless of the fd's nonblocking flag.

```ruby
# before
nr_fork.times { expect(rd.sysread(1)).to eq('.') }

# after
nr_fork.times { expect(rd.read(1)).to eq('.') }
```

Assertions (`lines.size == nr_signal`, `uniq.size == nr_fork`) are unchanged.

## Verification (macOS / Ruby 3.2.6)

- After fix: 0 failures out of 200 reads in the amplified race script
- `bundle exec rspec spec/async_watcher_spec.rb` passed 10 consecutive runs
- Full suite (`bundle exec rspec spec/`) passed: 44 examples, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)